### PR TITLE
fix: greater z-index on Codemirror-tooltip element

### DIFF
--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -10,3 +10,7 @@
     margin-right: 15px !important;
   }
 }
+
+.CodeMirror-lint-tooltip {
+  z-index: 1400;
+}


### PR DESCRIPTION
fixes #6 

## What
Add greater z-index to JSON lint tooltip (CodeMirror component)

## Why
As seen on #6 the tooltip was wrong placed behind 'Add Job' modal.

## How
Edited z-index of Codemirror-tooltip element adding a value of `1400` to z-index property.
The value `1400` was choosen because the modal itself has a value of `1300`