### PR TITLE
Make JobStatusChip transparent when there are no jobs in it

### DIFF
--- a/packages/ui/src/components/JobStatusChip/index.tsx
+++ b/packages/ui/src/components/JobStatusChip/index.tsx
@@ -13,12 +13,16 @@ type TProps = {
 
 export default function JobStatusChip(props: TProps) {
   const backgroundColor = useJobStatusColor(props.status);
+  const style = {
+    color: '#fff',
+    backgroundColor,
+  };
+  if (isUndefined(props.label) || props.label <= 0) {
+    style.opacity = 0.5;
+  }
   return (
     <Chip
-      style={{
-        color: '#fff',
-        backgroundColor,
-      }}
+      style={style}
       size={props.size}
       className={props.className}
       label={isUndefined(props.label) ? props.status : props.label}


### PR DESCRIPTION
This helps to better see states with jobs:

![image](https://user-images.githubusercontent.com/3694800/130911824-22464bed-d969-4d20-99ea-8d5ff0793843.png)
