### PR TITLE
feat: support object progress

### DIFF
--- a/packages/root/src/gql/type-defs/job.ts
+++ b/packages/root/src/gql/type-defs/job.ts
@@ -28,7 +28,7 @@ export const jobTypeDef = gql`
     data: String
     status: JobStatus!
     returnValue: String
-    progress: Int!
+    progress: JSON!
     attemptsMade: Int!
     failedReason: String
     stacktrace: [String]!

--- a/packages/root/src/queue.ts
+++ b/packages/root/src/queue.ts
@@ -27,7 +27,7 @@ export abstract class Job {
   public abstract get name(): string;
   public abstract get data(): any;
   public abstract get returnvalue(): unknown;
-  public abstract get progress(): number;
+  public abstract get progress(): number | Record<string, any>;
   public abstract get attemptsMade(): number;
   public abstract get failedReason(): Maybe<string>;
   public abstract get stacktrace(): string[];

--- a/packages/root/src/typings/gql.ts
+++ b/packages/root/src/typings/gql.ts
@@ -34,7 +34,7 @@ export type Job = {
   data?: Maybe<Scalars['String']>;
   status: JobStatus;
   returnValue?: Maybe<Scalars['String']>;
-  progress: Scalars['Int'];
+  progress: Scalars['JSON'];
   attemptsMade: Scalars['Int'];
   failedReason?: Maybe<Scalars['String']>;
   stacktrace: Array<Maybe<Scalars['String']>>;

--- a/packages/ui/src/screens/jobs/List/Job/index.tsx
+++ b/packages/ui/src/screens/jobs/List/Job/index.tsx
@@ -77,7 +77,7 @@ const Job = ({
           {job.processingTime ? ms(job.processingTime) : null}
         </TableCell>
         <TableCell>{job.attemptsMade}</TableCell>
-        <TableCell>{job.progress}</TableCell>
+        <TableCell>{JSON.stringify(job.progress)}</TableCell>
       </TableRow>
       {showExtra && (
         <TableRow>

--- a/packages/ui/src/typings/gql.ts
+++ b/packages/ui/src/typings/gql.ts
@@ -34,7 +34,7 @@ export type Job = {
   data?: Maybe<Scalars['String']>;
   status: JobStatus;
   returnValue?: Maybe<Scalars['String']>;
-  progress: Scalars['Int'];
+  progress: Scalars['JSON'];
   attemptsMade: Scalars['Int'];
   failedReason?: Maybe<Scalars['String']>;
   stacktrace: Array<Maybe<Scalars['String']>>;


### PR DESCRIPTION
Fix #14, below is the source code of bullmq:

https://github.com/taskforcesh/bullmq/blob/cf0710cfe322eb2147f439364b425763b4d5c592/src/classes/job.ts#L246

![image](https://user-images.githubusercontent.com/6647633/156012963-5fca0084-78a3-4b04-ba8d-a7a4c12a326a.png)

https://github.com/taskforcesh/bullmq/blob/cf0710cfe322eb2147f439364b425763b4d5c592/src/classes/scripts.ts#L231

![image](https://user-images.githubusercontent.com/6647633/156015279-8fb807a8-4f17-4b07-8ef9-f091e8fca258.png)


I'm not sure is it ok to just change 'progress' from `Int` to `JSON`, but it works for me in both cases:

![image](https://user-images.githubusercontent.com/6647633/156013927-ecea73f5-8286-4805-bc1e-d7d6e0fdd4c4.png)