### PR TITLE
Add optional Redis prefix option

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,6 +19,7 @@ Options:
   --bullmq                     use bullmq instead of bull
   -p, --port <number>          server's port (default: "3000")
   --host <string>              server's host (default: "localhost")
+  --prefix <string>            redis key prefix (bull/bullmq)
   -m, --metrics                enable metrics collector
   --max-metrics <number>       max metrics (default: "100")
   --metrics-interval <number>  metrics collection interval in seconds (default: "3600")

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ program
   .option('--bullmq', 'use bullmq instead of bull')
   .option('-p, --port <number>', "server's port", '3000')
   .option('--host <string>', "server's host", 'localhost')
+  .option('--prefix <string>', 'redis key prefix', undefined)
   .option('-m, --metrics', 'enable metrics collector')
   .option('--max-metrics <number>', 'max metrics', '100')
   .option(
@@ -44,13 +45,16 @@ const options = program.opts();
           require('@bull-monitor/root/dist/bullmq-adapter').BullMQAdapter;
         return new Adapter(
           new BullMqQueue(name, {
+            ...(options.prefix ? {prefix: options.prefix}: {}),
             connection,
           })
         );
       } else {
         const Adapter =
           require('@bull-monitor/root/dist/bull-adapter').BullAdapter;
-        return new Adapter(new BullQueue(name, options.redisUri));
+        return new Adapter(new BullQueue(name, options.redisUri, {
+          ...(options.prefix ? {prefix: options.prefix}: {})
+        }));
       }
     }),
     metrics: options.metrics && {


### PR DESCRIPTION
This proposal PR adds an option to set Redis prefix in the CLI: in our current setup we use it with BullMQ and Bull to separate various environments (e.g. stage, development etc.) in the same Redis instance.